### PR TITLE
Add distinction for Odyssey/HP Motion controllers

### DIFF
--- a/Models/ControllerEnum.cs
+++ b/Models/ControllerEnum.cs
@@ -10,6 +10,8 @@
         
         vivePro = 4,
         wmr = 8,
+        odyssey = 9,
+        hpMotion = 10,
 
         picoNeo3 = 33,
         picoNeo2 = 34,

--- a/Utils/ReplayUtils.cs
+++ b/Utils/ReplayUtils.cs
@@ -326,7 +326,10 @@ namespace BeatLeader_Server.Utils
             if (lowerController.Contains("oculus touch") || lowerController.Contains("rift cv1")) return ControllerEnum.oculustouch;
             if (lowerController.Contains("rift s") || lowerController.Contains("quest")) return ControllerEnum.oculustouch2;
 
+            if (lowerController.Contains("066a")) return ControllerEnum.hpMotion;
+            if (lowerController.Contains("065d")) return ControllerEnum.odyssey;
             if (lowerController.Contains("windows")) return ControllerEnum.wmr;
+
             if (lowerController.Contains("nolo")) return ControllerEnum.nolo;
             if (lowerController.Contains("disco")) return ControllerEnum.disco;
             if (lowerController.Contains("hands")) return ControllerEnum.hands;


### PR DESCRIPTION
These controllers have noticeably different weights and ergonomics compared to the regular WMR controllers, so distinguish between them.

WMR "Gen 1" Controller (Dell Visor/Lenovo Explorer/etc): `OpenVR Controller(WindowsMR: 0x045E/0x065B/0/2)`
Odyssey Controller (Samsung HMD Odyssey/Odyssey+): `OpenVR Controller(WindowsMR: 0x045E/0x065D/0/2)`
HP Motion Controller (Reverb G2): `OpenVR Controller(WindowsMR: 0x045E/0x066A/0/2)`

(I don't have Docker so I've not been able to test, oops)