### PR TITLE
Correctly reverted no search to no match (look after image pr)

### DIFF
--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -389,12 +389,7 @@ namespace BeatLeader_Server.Controllers
             List<PlayerMetadata> searchMatch = PlayerSearchService.Search(search);
             List<string> ids = searchMatch.Select(m => m.Id).ToList();
 
-            if (searchMatch.Count > 0)
-            {
-                request = request.Where(p => ids.Contains(p.Id));
-            } else if (search.Length > 0) {
-                request = request.Where(p => false);
-            }
+            request = request.Where(p => ids.Contains(p.Id));
 
             if (clans != null)
             {

--- a/Utils/ImageUtils.cs
+++ b/Utils/ImageUtils.cs
@@ -1,61 +1,88 @@
 ﻿using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Processing;
 
-namespace BeatLeader_Server.Utils
+namespace BeatLeader_Server.Utils;
+
+public class ImageUtils
 {
-    public class ImageUtils
+    public static (string, MemoryStream) GetFormatAndResize(MemoryStream memoryStream)
     {
-        public static (string, MemoryStream) GetFormatAndResize(MemoryStream memoryStream)
+        Image image = Image.Load(memoryStream, out IImageFormat format);
+        Size size = image.Size();
+
+        int width = Math.Min(200, size.Width);
+        int height = (int)(size.Height / (float)size.Width * width);
+
+        if (width < height)
         {
-            IImageFormat format;
-            Image image = Image.Load(memoryStream, out format);
-            Size size = image.Size();
-
-            int width = Math.Min(200, size.Width);
-            int height = (int)(((float)size.Height / (float)size.Width) * (float)width);
-
-            if (width < height) {
-                image.Mutate(i => i.Resize(width, height).Crop(new Rectangle(0, height / 2 - width / 2, width, width)));
-            } else if (width > height) {
-                image.Mutate(i => i.Resize(width, height).Crop(new Rectangle(width / 2 - height / 2, 0, height, height)));
-            } else {
-                image.Mutate(i => i.Resize(width, height));
-            }
-
-            var ms = new MemoryStream(5);
-            string extension;
-
-            if (format.Name == "GIF") {
-                image.SaveAsGif(ms);
-                extension = ".gif";
-            } else {
-                image.SaveAsPng(ms);
-                extension = ".png";
-            }
-            ms.Position = 0;
-
-            return (extension, ms);
+            image.Mutate(imageProcessingContext => imageProcessingContext.Resize(width, height).Crop(new Rectangle(0, (height / 2) - (width / 2), width, width)));
         }
-        
-        public static (string, MemoryStream) GetFormat(MemoryStream memoryStream)
+        else if (width > height)
         {
-            IImageFormat format;
-            Image image = Image.Load(memoryStream, out format);
-
-            var ms = new MemoryStream(5);
-            string extension;
-
-            if (format.Name == "GIF") {
-                image.SaveAsGif(ms);
-                extension = ".gif";
-            } else {
-                image.SaveAsPng(ms);
-                extension = ".png";
-            }
-            ms.Position = 0;
-
-            return (extension, ms);
+            image.Mutate(imageProcessingContext => imageProcessingContext.Resize(width, height).Crop(new Rectangle((width / 2) - (height / 2), 0, height, height)));
         }
+        else
+        {
+            image.Mutate(imageProcessingContext => imageProcessingContext.Resize(width, height));
+        }
+
+        MemoryStream ms = new(5);
+        string extension;
+
+        if (format.Name == "GIF")
+        {
+            image.SaveAsGif(ms);
+            extension = ".gif";
+        }
+        else
+        {
+            WebpEncoder webpEncoder = new()
+            {
+                NearLossless = true,
+                NearLosslessQuality = 80,
+                TransparentColorMode = WebpTransparentColorMode.Preserve,
+                Quality = 20,
+            };
+
+            image.SaveAsWebp(ms, webpEncoder);
+            extension = ".webp";
+        }
+
+        ms.Position = 0;
+
+        return (extension, ms);
+    }
+
+    public static (string, MemoryStream) GetFormat(MemoryStream memoryStream)
+    {
+        Image image = Image.Load(memoryStream, out IImageFormat format);
+
+        MemoryStream ms = new(5);
+        string extension;
+
+        if (format.Name == "GIF")
+        {
+            image.SaveAsGif(ms);
+            extension = ".gif";
+        }
+        else
+        {
+            WebpEncoder webpEncoder = new()
+            {
+                NearLossless = true,
+                NearLosslessQuality = 80,
+                TransparentColorMode = WebpTransparentColorMode.Preserve,
+                Quality = 20,
+            };
+
+            image.SaveAsWebp(ms, webpEncoder);
+            extension = ".webp";
+        }
+
+        ms.Position = 0;
+
+        return (extension, ms);
     }
 }

--- a/Utils/MapListUtils/Search.cs
+++ b/Utils/MapListUtils/Search.cs
@@ -57,14 +57,9 @@ public static partial class MapListUtils
 
         matches = SongSearchService.Search(search);
 
-        if (matches.Count > 0)
-        {
-            IEnumerable<string> ids = matches.Select(songMetadata => songMetadata.Id);
+        IEnumerable<string> ids = matches.Select(songMetadata => songMetadata.Id);
 
-            return sequence.Where(leaderboard => ids.Contains(leaderboard.SongId));
-        }
-
-        return sequence.Where(s => false);
+        return sequence.Where(leaderboard => ids.Contains(leaderboard.SongId));
     }
 
     public static string GetSearchFilters(this string search,


### PR DESCRIPTION
Don't use search length for anything, you should always be using matches, because you can have no search, have search filters. EX:star>3 breaks with your code. The only reason for the if's to exist was for them to return everything if no match, but since that is not the behavior that is wanted, the only thing that needs to be changed is the removal of the ifs.