### PR TITLE
Improve grammar for submission error

### DIFF
--- a/Controllers/ReplayController.cs
+++ b/Controllers/ReplayController.cs
@@ -278,7 +278,7 @@ namespace BeatLeader_Server.Controllers
                 leaderboard = await LeaderboardControllerHelper.GetByHash(dbContext, info.hash, info.difficulty, info.mode);
                 if (leaderboard == null)
                 {
-                    return NotFound("Such leaderboard not exists");
+                    return NotFound("No such leaderboard exists.");
                 }
             }
 


### PR DESCRIPTION
(At least on Quest, untested on PC) The the BeatLeader mod attempts to submit replays of DLC songs, yielding the error `Such leaderboard not exists`. The slight grammatical error irked me, and I thought I might as well make a PR. This changes it to `No such leaderboard exists.`