### PR TITLE
Honor showAllRatings in star rating filters

### DIFF
--- a/Utils/ScoreListUtils.cs
+++ b/Utils/ScoreListUtils.cs
@@ -241,6 +241,7 @@ namespace BeatLeader_Server.Utils {
             }
             if (stars_from != null) {
                 sequence = sequence.Where(s => (
+                        showAllRatings ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.nominated ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.qualified ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.ranked) && 
@@ -248,6 +249,7 @@ namespace BeatLeader_Server.Utils {
             }
             if (stars_to != null) {
                 sequence = sequence.Where(s => (
+                        showAllRatings ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.nominated ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.qualified ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.ranked) && 

--- a/Utils/ScoreListUtilsAll.cs
+++ b/Utils/ScoreListUtilsAll.cs
@@ -295,6 +295,7 @@ namespace BeatLeader_Server.Utils {
             }
             if (stars_from != null) {
                 sequence = sequence.Where(s => (
+                        showAllRatings ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.nominated ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.qualified ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.ranked) && 
@@ -303,6 +304,7 @@ namespace BeatLeader_Server.Utils {
             }
             if (stars_to != null) {
                 sequence = sequence.Where(s => (
+                        showAllRatings ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.nominated ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.qualified ||
                         s.Leaderboard.Difficulty.Status == DifficultyStatus.ranked) && 


### PR DESCRIPTION
I've been really late to realizing the value of unranked star ratings and the skill triangle, but now both have breathed new life into the game for me. It's granted me new ways to quickly find very fun maps to play. These days BL is my primary source for finding new maps, and I've written my own [tools](https://plebsaber.stream/tools) for using the api. But nothing beats using beatleader-website, since that's the only place to see star ratings for unranked maps. Now that I've been spoiled by these delicious triangles and star ratings, I want more.

I've been going to player profiles and paginating through their recently played maps to see what I might like (essentially using the player scores list api). There's a star rating filter that would be useful for me in this context, but it currently only returns star ratings for ranked maps.

This PR aims to honor the showAllRatings setting, and show the star ratings for unranked stars in a score list filter. As I'm submitting this, I've only changed stars_from and stars_to, since that would address my use case.

I also see that the same change could be applied to accrating_from/to, passrating_from/to, techrating_from/to. Since this is my first PR here I figured I should keep my changes minimal and didn't touch those yet. I think these are only currently used when a user clicks on the skill triangle, which sends them to the maps/ranked endpoint. So I'm guessing the omission of all ratings is intentional there. However, I'd frankly find a LOT of value in an all ratings version of that endpoint. Something to consider. I'd be happy to try to workshop a change for that too, although I should set up a proper testing environment, which I haven't done yet.